### PR TITLE
Only define "str_ends_with" when it's not already defined by PHP

### DIFF
--- a/src/load-assets.php
+++ b/src/load-assets.php
@@ -1,13 +1,14 @@
 /**
  * Loader utils
  */
-
-function str_ends_with( $haystack, $needle ) {
-  $length = strlen( $needle );
-  if( !$length ) {
-      return true;
+if (! function_exists('str_ends_with')) {
+  function str_ends_with( $haystack, $needle ) {
+    $length = strlen( $needle );
+    if( !$length ) {
+        return true;
+    }
+    return substr( $haystack, -$length ) === $needle;
   }
-  return substr( $haystack, -$length ) === $needle;
 }
 
 function is_js($path) {


### PR DESCRIPTION
PHP8 [already includes](https://www.php.net/manual/en/function.str-ends-with.php) a definition for the function "str_ends_with". To handle Wordpress installations running PHP8+, the plugin should only define that function if it is not already defined.

Without this change, WordPress gives an error when activating the plugin.